### PR TITLE
Updated template to now support Amazon Corretto 8 vs Java8

### DIFF
--- a/backend/template.yaml
+++ b/backend/template.yaml
@@ -542,7 +542,7 @@ Resources:
       FunctionName: 
         Ref: JavaWebAuthnFuncName
       CodeUri: lambda-functions/JavaWebAuthnLib/
-      Runtime: java8
+      Runtime: java8.a12
       Handler: com.yubicolabs.App::handleRequest
       Timeout: 30
       MemorySize: 1408


### PR DESCRIPTION
This WebAuthn Starter Kit is using AWS Lambda Java 8 runtime as the host for the Yubico WebAuthn Java library. With Amazon's recent migration away from Java 8 in favor of Amazon Corretto 8, we need to update the CloudFormation deployment script to utilize Amazon Corretto 8 vs Java8 engine (uses runtime: Java OpenJDK).

The Java8 managed runtime in AWS Lambda will be migrated from the current Open Java Development Kit (OpenJDK) implementation to the latest Amazon Corretto implementation very soon and this just gets on top of it.

Change made: Runtime: java8 → Runtime: java8.a12