### PR TITLE
Fixed credential ID length guidance in Starter Kit

### DIFF
--- a/backend/Database.md
+++ b/backend/Database.md
@@ -58,7 +58,7 @@ CREATE TABLE registrationRequests (
 CREATE TABLE credentialRegistrations (
     username TEXT,
     userHandle TEXT,
-    credentialId TEXT,
+    credentialId NVARCHAR(1023),
     registration TEXT,
     creationDate DATETIME DEFAULT CURRENT_TIMESTAMP,
     lastUsedDate DATETIME,

--- a/scripts/Mac-Linux/deployStarterKit.json
+++ b/scripts/Mac-Linux/deployStarterKit.json
@@ -1,9 +1,9 @@
 {
-  "AWS_CLI_PROFILE": "yubico-dev",
+  "AWS_CLI_PROFILE": "",
   "AWS_REGION": "",
   "S3_BUCKET_NAME": "",
   "CF_STACK_NAME": "",
-  "SUFFIX": "rcdemo",
+  "SUFFIX": "",
   "USER_POOL_NAME": "",
   "DATABASE_NAME": "",
   "DATABASE_MASTER_USERNAME": "",


### PR DESCRIPTION
Feedback from customer indicated that the credential ID length in the starter kit prevented some authenticators from registering. Database.MD script was modified to ensure the credential ID length was in alignment with the WebAuthn spec.

New DB was tested in a deployment, and no disruptions were found 

---
Another change added as it was found the deploy.json file contained some artifacts from development including the AWS Profile and Suffix